### PR TITLE
v1.1.0 - Update to AWS CDK v2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,10 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-'aws-cdk.core' = "~=1.147.0"
-'aws-cdk.aws-ec2' = "~=1.147.0"
-'aws-cdk.aws-efs' = "~=1.147.0"
-'aws-cdk.aws-iam' = "~=1.147.0"
+aws-cdk-lib = "~=2.24.1"
+constructs = "~=10.1.11"
 docker = "*"
 paramiko = ">=2.10.1"
 PyYAML = "*"
@@ -19,4 +17,4 @@ pyflakes = "*"
 pylint = "*"
 
 [requires]
-python_version = "3.8"
+python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "04b37eaa3f4fcb329305f6b21403bce40709b29a9f8b899d68bf7bdb85248656"
+            "sha256": "b2893b2eb8c5281011842cf2cb4d09c1137a4c562529e23941238ad7cd443a48"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3.10"
         },
         "sources": [
             {
@@ -21,146 +21,49 @@
                 "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
                 "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.4.0"
         },
-        "aws-cdk.assets": {
+        "aws-cdk-lib": {
             "hashes": [
-                "sha256:391ce80af2d9961aabb1becd01b1d4d4a7d4aad8ac0ec15ef1bf7fedb6d5f449",
-                "sha256:45d57d988f5ebc0e79c358e9bff5a95cafe94cd823a9dda90c8713fd4499482a"
-            ],
-            "version": "==1.147.0"
-        },
-        "aws-cdk.aws-cloudwatch": {
-            "hashes": [
-                "sha256:286543db45eba01e3916b829f2fbdd01a98f27ece6d7b4b11eb14344020b5463",
-                "sha256:eb635d85a77b6c8b59953d663947e71a4d07d8540998720fbc202a41805835be"
-            ],
-            "version": "==1.147.0"
-        },
-        "aws-cdk.aws-ec2": {
-            "hashes": [
-                "sha256:512e0f4d3e3bddfc3cf306f2f1cf279f64d8d5bd98a423e14610af23c111be70",
-                "sha256:bd241321afa4415b57ad0ffcecf230933dc8912acca9109dae72bbcb9ad21801"
+                "sha256:0ac1fa6bb90a8433ae5e9f3a13c369f9ac39d1347c8399ca2f6d242a888c841d",
+                "sha256:bf349fba338926eb6dc27719ca504771a262b9831e45e1acf6d924b41e38b7fe"
             ],
             "index": "pypi",
-            "version": "==1.147.0"
-        },
-        "aws-cdk.aws-efs": {
-            "hashes": [
-                "sha256:6c36872182a9b8381a841f90b427aa75bafa5a6f6c9066c3b3449c354236db28",
-                "sha256:ffc8560ae0645c4d69464eb580c87836572f2996f934e31d071358f84752f7fe"
-            ],
-            "index": "pypi",
-            "version": "==1.147.0"
-        },
-        "aws-cdk.aws-events": {
-            "hashes": [
-                "sha256:370271d59168ea695dd896ff878141abc116c80441f8e2d02f3609507d6ca23c",
-                "sha256:8a91f0d263f5a65433c56298351c971df07bea6ff68133aa68cfc956baf0a195"
-            ],
-            "version": "==1.147.0"
-        },
-        "aws-cdk.aws-iam": {
-            "hashes": [
-                "sha256:978e5f2fb94adf18ecc158ea8955dd514a12d25e9b9dc9b29d0d6cf9064aadd2",
-                "sha256:d6a8dfc29bbb8097971401ca0633f5eee4579221c6095efacd6605741c756175"
-            ],
-            "index": "pypi",
-            "version": "==1.147.0"
-        },
-        "aws-cdk.aws-kms": {
-            "hashes": [
-                "sha256:0869125dfda51665bc0b0b9f62a21088650332ba25a709820adb25999405aebe",
-                "sha256:799fd9fd774bc46cebe779d739fdee66ed8f8844aed48fcdbb2d5840fb935d3e"
-            ],
-            "version": "==1.147.0"
-        },
-        "aws-cdk.aws-logs": {
-            "hashes": [
-                "sha256:13ddbbc72bc9244773cb282216c2a86108c1c0c08d4a7518ecd83f74de1a709e",
-                "sha256:7b880ab4760711aeac0cc88fd4ef5cf5c19817cfc5449935335787950016e59e"
-            ],
-            "version": "==1.147.0"
-        },
-        "aws-cdk.aws-s3": {
-            "hashes": [
-                "sha256:360f6a56df76864af9b95f0fd9a6fc15b1c64154b07430f7b19e48eeefcb7ac7",
-                "sha256:3bd2aab76a439b49a080003c183cf492c088a8c456ba9fcbd26ea50cf637a535"
-            ],
-            "version": "==1.147.0"
-        },
-        "aws-cdk.aws-s3-assets": {
-            "hashes": [
-                "sha256:9e70d336e459ea1133f75f32b9ee5e8e77bb846dcdda3e74a1d171abb813a22a",
-                "sha256:deecb6e7e5d4b02a77070d285a3991c61513d03e78ac444b2a3c0b08f40d144a"
-            ],
-            "version": "==1.147.0"
-        },
-        "aws-cdk.aws-ssm": {
-            "hashes": [
-                "sha256:73dbf1fbdcde965e21917a5f4516b62cf105468e3130ce9506ba701d2c59a84c",
-                "sha256:8634a3b4eb696e1611fc4a73885f37e47abb66cfdc35179c2bc21d7f9b8b5fd1"
-            ],
-            "version": "==1.147.0"
-        },
-        "aws-cdk.cloud-assembly-schema": {
-            "hashes": [
-                "sha256:6c82871aeee399af492d9bb8fde3c2ade60d63909db084cb16ac06e85769ee92",
-                "sha256:8f3d2635d429a4116ac44a0786f3fb622b4c4d04237cb13fc2858c380bc2a270"
-            ],
-            "version": "==1.147.0"
-        },
-        "aws-cdk.core": {
-            "hashes": [
-                "sha256:34d4541e7827b375b0846675358c534509b69d5491f648dbb902bf26899f85f4",
-                "sha256:7d91cba45ef475c3cb99b585b32d396fce29f87f2389e29bfd26ca7d5d222192"
-            ],
-            "index": "pypi",
-            "version": "==1.147.0"
-        },
-        "aws-cdk.cx-api": {
-            "hashes": [
-                "sha256:333816c964beb6c87ca12eba4bd7220400d14732e0a6b170f3baf1f4ad366cc3",
-                "sha256:ce2647a1484e109494feaddb62663932ff080a7e61c1cdaf2198ff21191fc910"
-            ],
-            "version": "==1.147.0"
-        },
-        "aws-cdk.region-info": {
-            "hashes": [
-                "sha256:a342df09c8a601425dcb18c7bf34c600f1963351a0680bd00439ae414ec5767f",
-                "sha256:c5a5dfa04001d7297363def3d75c0850d6b70518f37901909afade003534764f"
-            ],
-            "version": "==1.147.0"
+            "version": "==2.24.1"
         },
         "bcrypt": {
             "hashes": [
-                "sha256:56e5da069a76470679f312a7d3d23deb3ac4519991a0361abc11da837087b61d",
-                "sha256:5b93c1726e50a93a033c36e5ca7fdcd29a5c7395af50a6892f5d9e7c6cfbfb29",
-                "sha256:63d4e3ff96188e5898779b6057878fecf3f11cfe6ec3b313ea09955d587ec7a7",
-                "sha256:81fec756feff5b6818ea7ab031205e1d323d8943d237303baca2c5f9c7846f34",
-                "sha256:a0584a92329210fcd75eb8a3250c5a941633f8bfaf2a18f81009b097732839b7",
-                "sha256:a67fb841b35c28a59cebed05fbd3e80eea26e6d75851f0574a9273c80f3e9b55",
-                "sha256:b589229207630484aefe5899122fb938a5b017b0f4349f769b8c13e78d99a8fd",
-                "sha256:c95d4cbebffafcdd28bd28bb4e25b31c50f6da605c81ffd9ad8a3d1b2ab7b1b6",
-                "sha256:cd1ea2ff3038509ea95f687256c46b79f5fc382ad0aa3664d200047546d511d1",
-                "sha256:cdcdcb3972027f83fe24a48b1e90ea4b584d35f1cc279d76de6fc4b13376239d"
+                "sha256:2b02d6bfc6336d1094276f3f588aa1225a598e27f8e3388f4db9948cb707b521",
+                "sha256:433c410c2177057705da2a9f2cd01dd157493b2a7ac14c8593a16b3dab6b6bfb",
+                "sha256:4e029cef560967fb0cf4a802bcf4d562d3d6b4b1bf81de5ec1abbe0f1adb027e",
+                "sha256:61bae49580dce88095d669226d5076d0b9d927754cedbdf76c6c9f5099ad6f26",
+                "sha256:6d2cb9d969bfca5bc08e45864137276e4c3d3d7de2b162171def3d188bf9d34a",
+                "sha256:7180d98a96f00b1050e93f5b0f556e658605dd9f524d0b0e68ae7944673f525e",
+                "sha256:7d9ba2e41e330d2af4af6b1b6ec9e6128e91343d0b4afb9282e54e5508f31baa",
+                "sha256:7ff2069240c6bbe49109fe84ca80508773a904f5a8cb960e02a977f7f519b129",
+                "sha256:88273d806ab3a50d06bc6a2fc7c87d737dd669b76ad955f449c43095389bc8fb",
+                "sha256:a2c46100e315c3a5b90fdc53e429c006c5f962529bc27e1dfd656292c20ccc40",
+                "sha256:cd43303d6b8a165c29ec6756afd169faba9396a9472cdff753fe9f19b96ce2fa"
             ],
-            "version": "==3.2.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.2.2"
         },
         "cattrs": {
             "hashes": [
                 "sha256:94b67b64cf92c994f8784c40c082177dc916e0489a73a9a36b24eb18a9db40c6",
                 "sha256:d55c477b4672f93606e992049f15d526dc7867e6c756cd6256d4af92e2b1e364"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7' and python_version < '4.0'",
             "version": "==22.1.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
-                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+                "sha256:6ae10321df3e464305a46e997da41ea56c1d311fb9ff1dd4e04d6f14653ec63a",
+                "sha256:8d15a5a7fde18536a249c49e07e8e462b8fc13de21b3c80e8a68315dfa227c99"
             ],
-            "version": "==2021.10.8"
+            "markers": "python_version >= '3.5'",
+            "version": "==2022.5.18"
         },
         "cffi": {
             "hashes": [
@@ -227,35 +130,39 @@
         },
         "constructs": {
             "hashes": [
-                "sha256:7e062512edbfd968ddaabdb640f0e5f7057ec4fabe8a3a06799aa163238c0e49",
-                "sha256:998b2d1cf5ca4e0aa494beafaa3328e482c3c74913961a0b4a8d7eec0dba8534"
+                "sha256:0d6c79bb5d32c593aa784e06fec47d4760daf92a77f97d41ba45b26a32cac03c",
+                "sha256:ca4e6ec13202356510c593479dbfd6814d5d83d204108715332551d633aae8f3"
             ],
-            "version": "==3.3.267"
+            "index": "pypi",
+            "version": "==10.1.11"
         },
         "cryptography": {
             "hashes": [
-                "sha256:0a3bf09bb0b7a2c93ce7b98cb107e9170a90c51a0162a20af1c61c765b90e60b",
-                "sha256:1f64a62b3b75e4005df19d3b5235abd43fa6358d5516cfc43d87aeba8d08dd51",
-                "sha256:32db5cc49c73f39aac27574522cecd0a4bb7384e71198bc65a0d23f901e89bb7",
-                "sha256:4881d09298cd0b669bb15b9cfe6166f16fc1277b4ed0d04a22f3d6430cb30f1d",
-                "sha256:4e2dddd38a5ba733be6a025a1475a9f45e4e41139d1321f412c6b360b19070b6",
-                "sha256:53e0285b49fd0ab6e604f4c5d9c5ddd98de77018542e88366923f152dbeb3c29",
-                "sha256:70f8f4f7bb2ac9f340655cbac89d68c527af5bb4387522a8413e841e3e6628c9",
-                "sha256:7b2d54e787a884ffc6e187262823b6feb06c338084bbe80d45166a1cb1c6c5bf",
-                "sha256:7be666cc4599b415f320839e36367b273db8501127b38316f3b9f22f17a0b815",
-                "sha256:8241cac0aae90b82d6b5c443b853723bcc66963970c67e56e71a2609dc4b5eaf",
-                "sha256:82740818f2f240a5da8dfb8943b360e4f24022b093207160c77cadade47d7c85",
-                "sha256:8897b7b7ec077c819187a123174b645eb680c13df68354ed99f9b40a50898f77",
-                "sha256:c2c5250ff0d36fd58550252f54915776940e4e866f38f3a7866d92b32a654b86",
-                "sha256:ca9f686517ec2c4a4ce930207f75c00bf03d94e5063cbc00a1dc42531511b7eb",
-                "sha256:d2b3d199647468d410994dbeb8cec5816fb74feb9368aedf300af709ef507e3e",
-                "sha256:da73d095f8590ad437cd5e9faf6628a218aa7c387e1fdf67b888b47ba56a17f0",
-                "sha256:e167b6b710c7f7bc54e67ef593f8731e1f45aa35f8a8a7b72d6e42ec76afd4b3",
-                "sha256:ea634401ca02367c1567f012317502ef3437522e2fc44a3ea1844de028fa4b84",
-                "sha256:ec6597aa85ce03f3e507566b8bcdf9da2227ec86c4266bd5e6ab4d9e0cc8dab2",
-                "sha256:f64b232348ee82f13aac22856515ce0195837f6968aeaa94a3d0353ea2ec06a6"
+                "sha256:093cb351031656d3ee2f4fa1be579a8c69c754cf874206be1d4cf3b542042804",
+                "sha256:0cc20f655157d4cfc7bada909dc5cc228211b075ba8407c46467f63597c78178",
+                "sha256:1b9362d34363f2c71b7853f6251219298124aa4cc2075ae2932e64c91a3e2717",
+                "sha256:1f3bfbd611db5cb58ca82f3deb35e83af34bb8cf06043fa61500157d50a70982",
+                "sha256:2bd1096476aaac820426239ab534b636c77d71af66c547b9ddcd76eb9c79e004",
+                "sha256:31fe38d14d2e5f787e0aecef831457da6cec68e0bb09a35835b0b44ae8b988fe",
+                "sha256:3b8398b3d0efc420e777c40c16764d6870bcef2eb383df9c6dbb9ffe12c64452",
+                "sha256:3c81599befb4d4f3d7648ed3217e00d21a9341a9a688ecdd615ff72ffbed7336",
+                "sha256:419c57d7b63f5ec38b1199a9521d77d7d1754eb97827bbb773162073ccd8c8d4",
+                "sha256:46f4c544f6557a2fefa7ac8ac7d1b17bf9b647bd20b16decc8fbcab7117fbc15",
+                "sha256:471e0d70201c069f74c837983189949aa0d24bb2d751b57e26e3761f2f782b8d",
+                "sha256:59b281eab51e1b6b6afa525af2bd93c16d49358404f814fe2c2410058623928c",
+                "sha256:731c8abd27693323b348518ed0e0705713a36d79fdbd969ad968fbef0979a7e0",
+                "sha256:95e590dd70642eb2079d280420a888190aa040ad20f19ec8c6e097e38aa29e06",
+                "sha256:a68254dd88021f24a68b613d8c51d5c5e74d735878b9e32cc0adf19d1f10aaf9",
+                "sha256:a7d5137e556cc0ea418dca6186deabe9129cee318618eb1ffecbd35bee55ddc1",
+                "sha256:aeaba7b5e756ea52c8861c133c596afe93dd716cbcacae23b80bc238202dc023",
+                "sha256:dc26bb134452081859aa21d4990474ddb7e863aa39e60d1592800a8865a702de",
+                "sha256:e53258e69874a306fcecb88b7534d61820db8a98655662a3dd2ec7f1afd9132f",
+                "sha256:ef15c2df7656763b4ff20a9bc4381d8352e6640cfeb95c2972c38ef508e75181",
+                "sha256:f224ad253cc9cea7568f49077007d2263efa57396a2f2f78114066fd54b5c68e",
+                "sha256:f8ec91983e638a9bcd75b39f1396e5c0dc2330cbd9ce4accefe68717e6779e0a"
             ],
-            "version": "==36.0.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==37.0.2"
         },
         "docker": {
             "hashes": [
@@ -267,11 +174,11 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:ed5799dc1260d2421564c21567f7ec84cffb39f149cf0e5e7e0aa6548e1f7288",
-                "sha256:f734ede30b0d3f21f91d17bb83216e3ee780df0738a293e15d08925279623782"
+                "sha256:1ce181e67ce038f3a187f003df3e744d653c8e5bae1387e405003cac2c7d0c97",
+                "sha256:a32d91b08dba53b3c419eb4e5e1d9aae2c9032e0e8004aec9bc7192881a0c422"
             ],
-            "markers": "python_version <= '3.10'",
-            "version": "==1.0.0rc3"
+            "markers": "python_version < '3.11'",
+            "version": "==1.0.0rc6"
         },
         "idna": {
             "hashes": [
@@ -283,18 +190,19 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:8e61eb860a9a76c66cde44ce3a1e6f66b4b5ab3683131ca49124785f75f3792c",
-                "sha256:d393c72aa1864de301b95b65b161efc8838999b32099cd8d7cda6a03cea3cff9"
+                "sha256:6a9f587cdc1b03129375f9faed876d864383d2b341471c1296a0040622fe938a",
+                "sha256:d7ea32e1d6c8aa597be7ecf10eb0e05355db60e6ca986f82dab3fb5aa52d914f"
             ],
-            "version": "==1.56.0"
+            "markers": "python_version ~= '3.7'",
+            "version": "==1.59.0"
         },
         "paramiko": {
             "hashes": [
-                "sha256:ac6593479f2b47a9422eca076b22cff9f795495e6733a64723efc75dd8c92101",
-                "sha256:ddb1977853aef82804b35d72a0e597b244fa326c404c350bd00c5b01dbfee71a"
+                "sha256:003e6bee7c034c21fbb051bf83dc0a9ee4106204dd3c53054c71452cc4ec3938",
+                "sha256:655f25dc8baf763277b933dfcea101d636581df8d6b9774d1fb653426b72c270"
             ],
             "index": "pypi",
-            "version": "==2.10.3"
+            "version": "==2.11.0"
         },
         "publication": {
             "hashes": [
@@ -323,6 +231,7 @@
                 "sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b",
                 "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.5.0"
         },
         "python-dateutil": {
@@ -330,6 +239,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "pyyaml": {
@@ -384,20 +294,23 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
-                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
+                "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708",
+                "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"
             ],
-            "version": "==4.1.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==4.2.0"
         },
         "urllib3": {
             "hashes": [
                 "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
                 "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.9"
         },
         "websocket-client": {
@@ -405,16 +318,26 @@
                 "sha256:50b21db0058f7a953d67cc0445be4b948d7fc196ecbeb8083d68d94628e4abf6",
                 "sha256:722b171be00f2b90e1d4fb2f2b53146a536ca38db1da8ff49c972a4e1365d0ef"
             ],
+            "markers": "python_version >= '3.7'",
             "version": "==1.3.2"
         }
     },
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:3975a0bd5373bdce166e60c851cfcbaf21ee96de80ec518c1f4cb3e94c3fb334",
-                "sha256:ab7f36e8a78b8e54a62028ba6beef7561db4cdb6f2a5009ecc44a6f42b5697ef"
+                "sha256:14ffbb4f6aa2cf474a0834014005487f7ecd8924996083ab411e7fa0b508ce0b",
+                "sha256:f4e4ec5294c4b07ac38bab9ca5ddd3914d4bf46f9006eb5c0ae755755061044e"
             ],
-            "version": "==2.6.6"
+            "markers": "python_full_version >= '3.6.2'",
+            "version": "==2.11.5"
+        },
+        "dill": {
+            "hashes": [
+                "sha256:7e40e4a70304fd9ceab3535d36e58791d9c4a776b38ec7f7ec9afc8d3dca4d4f",
+                "sha256:9f9734205146b2b353ab3fec9af0070237b6ddae78452af83d2fca84d739e675"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.0'",
+            "version": "==0.3.4"
         },
         "flake8": {
             "hashes": [
@@ -429,6 +352,7 @@
                 "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
                 "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"
             ],
+            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
             "version": "==5.10.1"
         },
         "lazy-object-proxy": {
@@ -471,6 +395,7 @@
                 "sha256:fccdf7c2c5821a8cbd0a9440a456f5050492f2270bd54e94360cac663398739b",
                 "sha256:fd45683c3caddf83abbb1249b653a266e7069a09f486daa8863fb0e7496a9fdb"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.7.1"
         },
         "mccabe": {
@@ -480,11 +405,20 @@
             ],
             "version": "==0.6.1"
         },
+        "platformdirs": {
+            "hashes": [
+                "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
+                "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.5.2"
+        },
         "pycodestyle": {
             "hashes": [
                 "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
                 "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.8.0"
         },
         "pyflakes": {
@@ -497,24 +431,97 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:349b149e88e4357ed4f77ac3a4e61c0ab965cda293b6f4e58caf73d4b24ae551",
-                "sha256:adc11bec00c2084bf55c81dd69e26f2793fef757547997d44b21aed038f74403"
+                "sha256:095567c96e19e6f57b5b907e67d265ff535e588fe26b12b5ebe1fc5645b2c731",
+                "sha256:705c620d388035bdd9ff8b44c5bcdd235bfb49d276d488dd2c8ff1736aa42526"
             ],
             "index": "pypi",
-            "version": "==3.0.0a4"
+            "version": "==2.13.9"
         },
-        "toml": {
+        "setuptools": {
             "hashes": [
-                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+                "sha256:68e45d17c9281ba25dc0104eadd2647172b3472d9e01f911efa57965e8d51a36",
+                "sha256:a43bdedf853c670e5fed28e5623403bad2f73cf02f9a2774e91def6bda8265a7"
             ],
-            "version": "==0.10.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==62.3.2"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
         },
         "wrapt": {
             "hashes": [
-                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
+                "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3",
+                "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b",
+                "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4",
+                "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2",
+                "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656",
+                "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3",
+                "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff",
+                "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310",
+                "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a",
+                "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57",
+                "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069",
+                "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
+                "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe",
+                "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87",
+                "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d",
+                "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b",
+                "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907",
+                "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f",
+                "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0",
+                "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28",
+                "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1",
+                "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853",
+                "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc",
+                "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3",
+                "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3",
+                "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164",
+                "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1",
+                "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c",
+                "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1",
+                "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7",
+                "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1",
+                "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320",
+                "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed",
+                "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1",
+                "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248",
+                "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c",
+                "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456",
+                "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77",
+                "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef",
+                "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1",
+                "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7",
+                "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
+                "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4",
+                "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d",
+                "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d",
+                "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8",
+                "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5",
+                "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471",
+                "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00",
+                "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68",
+                "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3",
+                "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d",
+                "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735",
+                "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d",
+                "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569",
+                "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7",
+                "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59",
+                "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5",
+                "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb",
+                "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b",
+                "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f",
+                "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462",
+                "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015",
+                "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"
             ],
-            "version": "==1.12.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.14.1"
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,18 +5,18 @@
   "packages": {
     "": {
       "dependencies": {
-        "aws-cdk": "^1.147.0"
+        "aws-cdk": "^2.24.1"
       }
     },
     "node_modules/aws-cdk": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-1.147.0.tgz",
-      "integrity": "sha512-ZBtZQjvDbgkFlZg6z7qm5ryMy2B1t+B2000avWnkGc0TQuv7YjdK6j+6uoDFKvsiIYepKKMgAX04scEimbbaGw==",
+      "version": "2.24.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.24.1.tgz",
+      "integrity": "sha512-fDcJW7tLbqsCvWB3eZY6glRrjRE45VqLT+JuKz3C2jIe6qXkwV8dBwYXElwY/tTCh/hDlpWtCNMRdhmrdE25GQ==",
       "bin": {
         "cdk": "bin/cdk"
       },
       "engines": {
-        "node": ">= 10.13.0 <13 || >=13.7.0"
+        "node": ">= 14.15.0"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
@@ -38,9 +38,9 @@
   },
   "dependencies": {
     "aws-cdk": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-1.147.0.tgz",
-      "integrity": "sha512-ZBtZQjvDbgkFlZg6z7qm5ryMy2B1t+B2000avWnkGc0TQuv7YjdK6j+6uoDFKvsiIYepKKMgAX04scEimbbaGw==",
+      "version": "2.24.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.24.1.tgz",
+      "integrity": "sha512-fDcJW7tLbqsCvWB3eZY6glRrjRE45VqLT+JuKz3C2jIe6qXkwV8dBwYXElwY/tTCh/hDlpWtCNMRdhmrdE25GQ==",
       "requires": {
         "fsevents": "2.3.2"
       }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "aws-cdk": "^1.147.0"
+    "aws-cdk": "^2.24.1"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,8 @@ classifiers = [
 	"Operating System :: OS Independent"
 ]
 dependencies = [
-	'aws-cdk.core ~= 1.147.0',
-	'aws-cdk.aws-ec2 ~= 1.147.0',
-	'aws-cdk.aws-efs ~= 1.147.0',
-	'aws-cdk.aws-iam ~= 1.147.0',
+	'aws-cdk-lib ~= 2.24.1',
+	'constructs ~= 10.1.11',
 	'docker ~= 5.0.3',
 	'paramiko ~= 2.9.2',
 	'PyYAML ~= 6.0',
@@ -20,7 +18,7 @@ entry-points = {console_scripts = {substrate = "substrate.substrate:main"}}
 license = {text = "CC-BY-4.0"}
 readme = "README.md"
 requires-python = ">=3.7"
-version = "1.0.2"
+version = "1.1.0"
 
 [project.urls]
 Homepage = "https://github.com/seelabutk/substrate/"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,8 @@
 [options]
 include_package_data = True
 install_requires =
-  aws-cdk.core ~= 1.147.0
-  aws-cdk.aws-ec2 ~= 1.147.0
-  aws-cdk.aws-efs ~= 1.147.0
-  aws-cdk.aws-iam ~= 1.147.0
+  aws-cdk.core ~= 2.24.1
+  constructs ~= 10.1.11
   docker ~= 5.0.3
   paramiko ~= 2.9.2
   PyYAML ~= 6.0

--- a/src/substrate/targets/aws_stack.py
+++ b/src/substrate/targets/aws_stack.py
@@ -2,11 +2,10 @@ import os
 import subprocess
 from time import sleep
 
-from aws_cdk.core import App
-import aws_cdk.aws_ec2 as ec2
-import aws_cdk.aws_efs as efs
-import aws_cdk.aws_iam as iam
-from aws_cdk.core import RemovalPolicy, Stack
+from aws_cdk import App, RemovalPolicy, Stack
+from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_efs as efs
+from aws_cdk import aws_iam as iam
 import requests
 
 
@@ -27,6 +26,12 @@ class AWSStack():
 		app.synth()
 
 	def start(self):
+		subprocess.run(
+			f'npx cdk bootstrap --app "substrate {self.tool.name} -c {self.path} synth"',  # noqa: E501
+			check=True,
+			shell=True
+		)
+
 		subprocess.run(
 			f'npx cdk deploy --require-approval never --app "substrate {self.tool.name} -c {self.path} synth"',  # noqa: E501
 			check=True,


### PR DESCRIPTION
AWS CDK v1 is out of support next month, so I've upgraded to using v2. v2 uses a new bootstrapping strategy which creates IAM roles for deployment. This makes UT's AWS restrictions harder to work with, so I've switched to testing with my personal account. I leave it as an exercise for the reader to make v2 and UT play nicely together.