### PR TITLE
args config

### DIFF
--- a/src/substrate/substrate.py
+++ b/src/substrate/substrate.py
@@ -21,13 +21,13 @@ TOOLS = {
 }
 
 def deep_merge(a, b):
-    r = copy.deepcopy(a)
-    for key, val in b.items():
-        if key in r and isinstance(r[key], dict) and isinstance(val, dict):
-            r[key] = deep_merge(r[key], val)
-        else:
-            r[key] = val
-    return r
+	r = copy.deepcopy(a)
+	for key, val in b.items():
+		if key in r and isinstance(r[key], dict) and isinstance(val, dict):
+			r[key] = deep_merge(r[key], val)
+		else:
+			r[key] = val
+	return r
 
 class Substrate():
 	def __init__(self, tool_name, config, path=None):

--- a/src/substrate/substrate.py
+++ b/src/substrate/substrate.py
@@ -20,11 +20,11 @@ TOOLS = {
 	'braid': Braid
 }
 
-def deepMerge(a, b):
+def deep_merge(a, b):
     r = copy.deepcopy(a)
     for key, val in b.items():
         if key in r and isinstance(r[key], dict) and isinstance(val, dict):
-            r[key] = deepMerge(r[key], val)
+            r[key] = deep_merge(r[key], val)
         else:
             r[key] = val
     return r
@@ -36,7 +36,7 @@ class Substrate():
 			path, pathconfig = parse_yaml(path)
 		
 		self.tool_name = tool_name
-		self.config = deepMerge(pathconfig, config)
+		self.config = deep_merge(pathconfig, config)
 		self.path = path
 		self._check_config()
 
@@ -163,8 +163,8 @@ def main():
 		help='[start, stop]',
 		metavar='ACTION'
 	)
-	parser.add_argument('-i', '--input' , dest='input_config', default='{}', type=str, nargs='?', const=1)
-	parser.add_argument('-p', '--path'  , dest='path')
+	parser.add_argument('-c', '--config' , dest='input_config', default='{}', type=str, nargs='?', const=1)
+	parser.add_argument('-f', '--config-file'  , dest='path')
 	args = parser.parse_args()
 
 	if args.action not in ['start', 'stop', 'synth']:

--- a/src/substrate/tools/generic_tool.py
+++ b/src/substrate/tools/generic_tool.py
@@ -35,7 +35,7 @@ class GenericTool(Tool):
 		arguments = self.config.get('args', [])
 		docker.services.create(
 			self.image,
-			endpoint_spec=EndpointSpec(ports={self.port: (self.internal_port, 'tcp')}),
+			endpoint_spec=EndpointSpec(ports={self.port: (self.internal_port, 'tcp', 'host')}),
 			mode=ServiceMode(
 				mode='replicated',
 				replicas=self.config['docker'].get('replicas', 1)

--- a/src/substrate/tools/generic_tool.py
+++ b/src/substrate/tools/generic_tool.py
@@ -31,6 +31,8 @@ class GenericTool(Tool):
 		mounts = super().start()
 		docker = from_env()
 		self.port = self.config['docker'].get('port', self.port)
+		environement_variables = self.config['docker'].get('env', [])
+		arguments = self.config.get('args', [])
 		docker.services.create(
 			self.image,
 			endpoint_spec=EndpointSpec(ports={self.port: (self.internal_port, 'tcp')}),
@@ -38,6 +40,8 @@ class GenericTool(Tool):
 				mode='replicated',
 				replicas=self.config['docker'].get('replicas', 1)
 			),
+			args=arguments,
+			env=environement_variables,
 			mounts=mounts,
 			name=self.name,
 			networks=[f'substrate-{self.name}-net'],

--- a/src/substrate/tools/generic_tool.py
+++ b/src/substrate/tools/generic_tool.py
@@ -31,7 +31,7 @@ class GenericTool(Tool):
 		mounts = super().start()
 		docker = from_env()
 		self.port = self.config['docker'].get('port', self.port)
-		environement_variables = self.config['docker'].get('env', [])
+		environment_variables = self.config['docker'].get('env', [])
 		arguments = self.config.get('args', [])
 		docker.services.create(
 			self.image,
@@ -41,7 +41,7 @@ class GenericTool(Tool):
 				replicas=self.config['docker'].get('replicas', 1)
 			),
 			args=arguments,
-			env=environement_variables,
+			env=environment_variables,
 			mounts=mounts,
 			name=self.name,
 			networks=[f'substrate-{self.name}-net'],

--- a/src/substrate/tools/tool.py
+++ b/src/substrate/tools/tool.py
@@ -23,7 +23,7 @@ class Tool():
 				mounts.append(
 					Mount(f'/data/{index}', data_path, type='bind', read_only=True)
 				)
-		else:
+		elif len(data_paths) == 1:
 			mounts.append(Mount('/data', data_paths[0], type='bind', read_only=True))
 
 		return mounts


### PR DESCRIPTION
Changes:
 - if path is specified, the parsed substrate.config.yaml dictionary is merged with the dictionary specified at the cli. Expanded Substrate constructor to reflect this.
 
 - added optional configs for specifying "args" and "env" for generic_tool. This is used with docker.services.create to specify command line arguments and environment variables to be passed into the container.
 
 - fixed a bug in tool.py where if the length of the data_sources is zero the program throws an exception with an out of bounds error. This also enables data_sources to not be specified.